### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,6 @@
 name: Unit tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cliveyg/poptape-items/security/code-scanning/4](https://github.com/cliveyg/poptape-items/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level (root) to apply to all jobs. Based on the workflow's functionality, the minimal required permission is `contents: read`. This ensures that the workflow has only the necessary permissions to access repository contents for tasks like checking out the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
