### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/post-merge-deployment.yml
+++ b/.github/workflows/post-merge-deployment.yml
@@ -1,6 +1,8 @@
 # deploys to server via ssh after successful merge into main
 # and then attempts to perform docker compose up
 name: Deploy to server
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cliveyg/poptape-items/security/code-scanning/3](https://github.com/cliveyg/poptape-items/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's operations, it primarily needs `contents: read` to interact with the repository. No write permissions are necessary since the workflow does not modify repository contents or perform actions requiring write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
